### PR TITLE
[PHASE 2] Test too short SESSION_HANDOVER.md

### DIFF
--- a/SESSION_HANDOVER.md
+++ b/SESSION_HANDOVER.md
@@ -1,0 +1,5 @@
+# Session Handoff
+
+Short handoff test.
+
+Only 5 lines total.


### PR DESCRIPTION
## Phase 2: Too Short SESSION_HANDOVER.md

**Purpose**: Verify workflow WARNS but still PASSES when file is too short

**Test Scenario**:
- SESSION_HANDOVER.md has only 5 lines (minimum is 10)
- File was updated in PR
- Missing startup prompt text

**Expected Result**: ⚠️ Workflow should WARN but PASS
**Expected Warnings**:
- "SESSION_HANDOVER.md seems too short (< 10 lines)"
- "Startup prompt should begin with: 'Read CLAUDE.md...'"

**Attack Vector**: Bypass content requirements with minimal file