### PR TITLE
test: validate explicit permissions in reusable workflows

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   session-handoff:
-    uses: maxrantil/.github/.github/workflows/session-handoff-check-reusable.yml@master
+    uses: maxrantil/.github/.github/workflows/session-handoff-check-reusable.yml@feat/issue-3-explicit-permissions
     with:
       base-branch: master
       handoff-file: SESSION_HANDOVER.md
       min-lines: 10
 
   pr-body-ai-attribution:
-    uses: maxrantil/.github/.github/workflows/pr-body-ai-attribution-check-reusable.yml@master
+    uses: maxrantil/.github/.github/workflows/pr-body-ai-attribution-check-reusable.yml@feat/issue-3-explicit-permissions
     with:
       block-ai-tools: true
       block-agent-mentions: true

--- a/.github/workflows/push-validation.yml
+++ b/.github/workflows/push-validation.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   protect-master:
     name: Protect Master Branch
-    uses: maxrantil/.github/.github/workflows/protect-master-reusable.yml@master
+    uses: maxrantil/.github/.github/workflows/protect-master-reusable.yml@feat/issue-3-explicit-permissions
     with:
       protected-branch: 'master'

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run Python Tests
-    uses: maxrantil/.github/.github/workflows/python-test-reusable.yml@feat/issue-13-python-test-validation
+    uses: maxrantil/.github/.github/workflows/python-test-reusable.yml@feat/issue-3-explicit-permissions
     with:
       python-version: '3.11'
       install-command: 'uv sync'

--- a/.github/workflows/test-pre-commit.yml
+++ b/.github/workflows/test-pre-commit.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-pre-commit:
     name: Test Pre-commit Execution
-    uses: maxrantil/.github/.github/workflows/pre-commit-check-reusable.yml@master
+    uses: maxrantil/.github/.github/workflows/pre-commit-check-reusable.yml@feat/issue-3-explicit-permissions
     with:
       python-version: '3.x'
       base-branch: master


### PR DESCRIPTION
## Test PR for maxrantil/.github#3

This PR tests the explicit permissions blocks added to reusable workflows in https://github.com/maxrantil/.github/pull/30

### Workflows Being Tested

All workflows now reference :

1. **python-test.yml** → python-test-reusable.yml with 
2. **test-pre-commit.yml** → pre-commit-check-reusable.yml with  + uv fix
3. **pr-validation.yml**:
   - session-handoff-check-reusable.yml with 
   - pr-body-ai-attribution-check-reusable.yml with 
4. **push-validation.yml** → protect-master-reusable.yml with 

### Success Criteria

✅ All workflows execute successfully without permission errors
✅ No GITHUB_TOKEN scope issues
✅ pre-commit workflow uses uv instead of pip
✅ All read-only workflows function correctly with restricted permissions

### Expected Outcome

All workflows should pass, demonstrating that explicit least-privilege permissions work correctly.

---

Related: maxrantil/.github#3